### PR TITLE
Allow linking of two sortable list

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -118,6 +118,11 @@ angular.module('ui.sortable', []).value('uiSortableConfig',{}).directive('uiSort
           })(opts.remove);
         }
 
+        // Extend config by uiSortableConnect if available
+        if (attrs.uiSortableConnect) {
+          angular.extend(opts, { connectWith: attrs.uiSortableConnect });
+        }
+
         // Create sortable
         element.sortable(opts);
       }


### PR DESCRIPTION
It's a simple feature. It allows to use the jQuery UI linking of two sortable lists like so:

Controller:

``` javascript
function TestCtrl($scope) {
  $scope.items1 = ['Item1', 'Item2', 'Item3'];
  $scope.items2 = [];
}
```

View:

``` html
<ul ui-sortable ui-sortable-connect=".group" ng-model="items1" class="group">
  <li ng-repeat="item in items1">{{ item }}</li>
</ul>
<ul ui-sortable ui-sortable-connect=".group" ng-model="items2" class="group">
  <li ng-repeat="item in items2">{{ item }}</li>
</ul>
```
