### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "angular-ui-date",
-  "version": "0.0.2",
-  "description": "This directive allows you to add a date-picker to your form elements.",
-  "author": "https://github.com/angular-ui/ui-date/graphs/contributors",
+  "name": "angular-ui-sortable",
+  "version": "0.0.1",
+  "description": "This directive allows you to jQueryUI Sortable.",
+  "author": "https://github.com/angular-ui/ui-sortable/graphs/contributors",
   "license": "MIT",
   "homepage": "http://angular-ui.github.com",
-  "main": "src/date.js",
-  "dependencies": {},
+  "main": "./src/sortable.js",
+  "dependencies": {
+  "angular": "~1.x",
+  "jquery-ui": ">= 1.9"
+  },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-testacular": "~0.3.0",
-    "grunt-contrib-jshint": "~0.2.0"
+    "angular-mocks": "~1.x"
   },
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git://github.com/angular-ui/ui-date.git"
+    "url": "git://github.com/angular-ui/ui-sortable.git"
   }
 }


### PR DESCRIPTION
The original file contents refer to ui-date, not ui-sortable. Copied ui-sortable entries blindly from components.json. The original version had dependencies to grunt, I have no idea whether they are needed or not.
