### PR TITLE
Call apply after stop callback.

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -30,6 +30,12 @@ angular.module('ui.sortable', [])
                 stop:null,
                 update:null
             };
+            
+            var apply = function(e, ui) {
+              if (ui.item.sortable.resort || ui.item.sortable.relocate) {
+                scope.$apply();
+              }
+            };
 
             angular.extend(opts, uiSortableConfig);
 
@@ -77,9 +83,6 @@ angular.module('ui.sortable', [])
                   ui.item.sortable.resort.$modelValue.splice(end, 0, ui.item.sortable.resort.$modelValue.splice(start, 1)[0]);
 
                 }
-                if (ui.item.sortable.resort || ui.item.sortable.relocate) {
-                  scope.$apply();
-                }
               };
 
             }
@@ -91,6 +94,11 @@ angular.module('ui.sortable', [])
                       if( callbacks[key] ){
                           // wrap the callback
                           value = combineCallbacks( callbacks[key], value );
+                          
+                          if ( key === 'stop' ){
+                              // call apply after stop
+                              value = combineCallbacks( value, apply );
+                          }
                       }
 
                       element.sortable('option', key, value);
@@ -101,6 +109,9 @@ angular.module('ui.sortable', [])
 
                     opts[key] = combineCallbacks(value, opts[key]);
               });
+              
+              // call apply after stop
+              opts.stop = combineCallbacks( opts.stop, apply );
 
               // Create sortable
 


### PR DESCRIPTION
Ensure $scope.$apply() is called after any provided 'stop' callback.
Fixes stop callback #27
[Fixed demo](http://jsfiddle.net/dYdYU/11/)
