### PR TITLE
Avoid bracking when combining with an Object

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -14,7 +14,9 @@ angular.module('ui.sortable', [])
               function combineCallbacks(first,second){
                   if( second && (typeof second === "function") ){
                       return function(e,ui){
+                        if( first && (typeof first === 'function') ){
                           first(e,ui);
+                        }
                           second(e,ui);
                       };
                   }


### PR DESCRIPTION
Avoid having this error 'Uncaught TypeError: object is not a function' when sorting elements on the drop event 
