### PR TITLE
Bypassing jQuery UI floating bug. (Cleaned PR)

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -23,7 +23,8 @@ angular.module('ui.sortable', [])
 
             var opts = {};
 
-            var ngOpts = {
+            // custom options for the directive
+            var dirOpts = {
               floating: undefined
             };
 
@@ -92,13 +93,13 @@ angular.module('ui.sortable', [])
               scope.$watch(attrs.uiSortable, function(newVal, oldVal){
                   angular.forEach(newVal, function(value, key){
 
-                      if ( key in ngOpts ) {
+                      if ( key in dirOpts ) {
                         // if its a custom option of the directive,
                         // handle it approprietly
                         if ( key === 'floating' && value !== undefined ) {
                           element.data("ui-sortable").floating = value;
-                          return;
                         }
+                        return;
                       }
 
                       if( callbacks[key] ){


### PR DESCRIPTION
Solving #19 (and possibly #29).
Provides the extra option "floating" to ui-sortable options.
(This is to bypass [jquery-ui known issue](bugs.jqueryui.com/ticket/7498).)

The default value is undefined, and has no effect.
If floating is set to true (or false), then jquery.ui.sortable plugin is forced to behave as if the list was horizontal (or vertical respectively).
[Example pen](http://codepen.io/thgreasi/pen/aKeru)
