### PR TITLE
Better Placeholder Detection

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -120,7 +120,10 @@ angular.module('ui.sortable', [])
               // If the received flag hasn't be set on the item, this is a
               // normal sort, if dropindex is set, the item was moved, so move
               // the items in the list.
-              if(!ui.item.sortable.received && ('dropindex' in ui.item.sortable) && !ui.item.sortable.isCanceled()) {
+              if(!ui.item.sortable.received &&
+                 ('dropindex' in ui.item.sortable) &&
+                 !ui.item.sortable.isCanceled()) {
+
                 scope.$apply(function () {
                   ngModel.$modelValue.splice(
                     ui.item.sortable.dropindex, 0,


### PR DESCRIPTION
Only remove placeholder elements if they don't have classes marking them as angular generated.  Fixes #62
