### PR TITLE
chore(grunt): adds grunt-conventional-changelog plugin

### DIFF
--- a/gruntFile.js
+++ b/gruntFile.js
@@ -2,6 +2,7 @@ module.exports = function (grunt) {
 
   grunt.loadNpmTasks('grunt-testacular');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-conventional-changelog');
 
   // Default task.
   grunt.registerTask('default', ['jshint', 'testacular']);
@@ -32,6 +33,11 @@ module.exports = function (grunt) {
         boss:true,
         eqnull:true,
         globals:{}
+      }
+    },
+    changelog: {
+      options: {
+        dest: 'CHANGELOG.md'
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-testacular": "~0.3.0",
-    "grunt-contrib-jshint": "~0.2.0"
+    "grunt-contrib-jshint": "~0.2.0",
+    "grunt-conventional-changelog": "~1.0.0"
   },
   "scripts": {},
   "repository": {


### PR DESCRIPTION
this is to auto generate changelogs based on conventional commit messages

for more info see http://github.com/btford/grunt-conventional-changelog
