### PR TITLE
Don't use 'use strict'; on the global scope

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  jQuery UI Sortable plugin wrapper
 
@@ -10,6 +8,8 @@ angular.module('ui.sortable', [])
   .directive('uiSortable', [
     'uiSortableConfig', '$timeout', '$log',
     function(uiSortableConfig, $timeout, $log) {
+      'use strict';
+
       return {
         require: '?ngModel',
         link: function(scope, element, attrs, ngModel) {


### PR DESCRIPTION
If this file will be concatenated with other files, it will enforce Strict Mode on all of the other code it's concatenated with.

Reference (under `How do you use it?`):
http://www.nczonline.net/blog/2012/03/13/its-time-to-start-using-javascript-strict-mode/

By moving `'use strict';` inside the function, we can prevent that and still get the benefits.
