### PR TITLE
chore(grunt): use surround

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,6 @@
   "browser": true,
   "eqnull": true,
   "expr": true,
-  "globalstrict": true,
   "immed": true,
   "indent": 2,
   "laxbreak": true,

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1,8 +1,9 @@
-'use strict';
 
 var myapp = angular.module('sortableApp', ['ui.sortable']);
 
 myapp.controller('sortableController', function ($scope) {
+  'use strict';
+
   var tmpList = [];
 
   for (var i = 1; i <= 6; i++){

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', ['jshint', 'karma:unit']);
   grunt.registerTask('serve', ['karma:continuous', 'dist', 'build:gh-pages', 'connect:continuous', 'watch']);
-  grunt.registerTask('dist', ['ngmin', 'uglify']);
+  grunt.registerTask('dist', ['ngmin', 'surround', 'uglify' ]);
   grunt.registerTask('coverage', ['jshint', 'karma:coverage']);
 
 
@@ -91,12 +91,24 @@ module.exports = function(grunt) {
     },
 
     uglify: {
-      options: {banner: '<%= meta.banner %>'},
       build: {
         expand: true,
         cwd: 'dist',
-        src: ['*.js'],
+        src: ['*.js', '!*.min.js'],
         ext: '.min.js',
+        dest: 'dist'
+      }
+    },
+
+    surround: {
+      options: {
+        prepend: '(function(window, angular, undefined) { \'use strict\';',
+        append: '})(window, window.angular);'
+      },
+      main: {
+        expand: true,
+        cwd: 'src',
+        src: ['*.js'],
         dest: 'dist'
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "angular-ui-publisher": "1.2.x",
     "grunt": "~0.4.x",
     "grunt-contrib-connect": "0.5.x",
+    "grunt-surround": "0.1.x",
     "grunt-contrib-jshint": "0.8.x",
     "grunt-contrib-uglify": "0.2.x",
     "grunt-contrib-watch": "0.5.x",


### PR DESCRIPTION
Following #134 and #133

Here is a fast implementation of what I mean.
Still we might use a real concatenation so we can test over the final result (don't know if it's really necessary...) 
