### PR TITLE
fix(sortable): race condition when removing from DOM

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -42,7 +42,9 @@ angular.module('ui.sortable', [])
             scope.$watch(attrs.ngModel+'.length', function() {
               // Timeout to let ng-repeat modify the DOM
               $timeout(function() {
-                element.sortable('refresh');
+                if (!!element.data('ui-sortable')) {
+                  element.sortable('refresh');
+                }
               });
             });
 

--- a/test/sortable.spec.js
+++ b/test/sortable.spec.js
@@ -29,6 +29,23 @@ describe('uiSortable', function() {
       });
     });
 
+    it('should not refresh sortable if destroyed', function() {
+      inject(function($compile, $rootScope, $timeout) {
+        var element;
+        var childScope = $rootScope.$new();
+        element = $compile('<div><ul ui-sortable ng-model="items"><li ng-repeat="item in items">{{ item }}</li></ul></div>')(childScope);
+        $rootScope.$apply(function() {
+          childScope.items = ['One', 'Two', 'Three'];
+        });
+
+        element.remove(element.firstChild);
+        expect(function() {
+          $timeout.flush()
+        }).not.toThrow();
+
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
There is a race condition when an ui-sortable element is removed from the DOM, because the angular wrapper uses a `$timeout` to call the `refresh` on the jquery plugin, which is not possible after the element has been removed from DOM.
This patch just ensure the element is still "pluginified" before making the final call.

Sample thrown error :

``` js
Error: cannot call methods on sortable prior to initialization; attempted to call method 'refresh'
    at Function.jQuery.extend.error (http://127.0.0.1:9393/bower_components/jquery/dist/jquery.js:248:9)
    at HTMLUListElement.<anonymous> (http://127.0.0.1:9393/bower_components/jquery-ui/ui/jquery-ui.js:487:15)
    at Function.jQuery.extend.each (http://127.0.0.1:9393/bower_components/jquery/dist/jquery.js:381:23)
    at jQuery.fn.jQuery.each (http://127.0.0.1:9393/bower_components/jquery/dist/jquery.js:137:17)
    at $.widget.bridge.$.fn.(anonymous function) [as sortable] (http://127.0.0.1:9393/bower_components/jquery-ui/ui/jquery-ui.js:483:9)
    at http://127.0.0.1:9393/bower_components/angular-ui-sortable/sortable.js:40:23
    at http://127.0.0.1:9393/bower_components/angular/angular.js:13677:28
    at completeOutstandingRequest (http://127.0.0.1:9393/bower_components/angular/angular.js:4193:10)
    at http://127.0.0.1:9393/bower_components/angular/angular.js:4494:7 
```
