### PR TITLE
Error: cannot call methods on sortable prior to initialization; attempted to call method 'option'

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -184,7 +184,8 @@ angular.module('ui.sortable', [])
                   // wrap the callback
                   value = combineCallbacks(callbacks[key], value);
                 }
-                element.sortable('option', key, value);
+                if(element.is(':visible'))
+                  element.sortable('option', key, value);
               });
             }, true);
 


### PR DESCRIPTION
when i use the ui-route and come out with the "Error: cannot call methods on sortable prior to initialization; attempted to call method 'option'".so give a small change when the sortable page is not removed then dont do sortable('option')
