### PR TITLE
fix(sortable): fix connected lists with helper for last spot drops

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -125,7 +125,7 @@ angular.module('ui.sortable', [])
               // the start and stop of repeat sections and sortable doesn't
               // respect their order (even if we cancel, the order of the
               // comments are still messed up).
-              if (hasSortingHelper(element)) {
+              if (hasSortingHelper(element) && !ui.item.sortable.received) {
                 // restore all the savedNodes except .ui-sortable-helper element
                 // (which is placed last). That way it will be garbage collected.
                 savedNodes = savedNodes.not(savedNodes.last());


### PR DESCRIPTION
When using sortable between two lists and a helper function (not 'clone') there is a problem if you drop an item at the last spot.
The first time it works, the second time it will add it as the first element of the list.
It continues this way for every even drop as the last item.
You can check it here:
http://codepen.io/anon/pen/FyaJs

Closes #186
