### PR TITLE
Making ui-sortable Require.js friendly

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -213,7 +213,9 @@ angular.module('ui.sortable', [])
           }
 
           // Create sortable
-          element.sortable(opts);
+          // PM: by loading jquery-ui.sortable via requirejs, the angular element stuff might
+          // not have $.fn.sortable at all. just use jQuery straight up.
+          $(element).sortable(opts);
         }
       };
     }


### PR DESCRIPTION
Hi there. You may or may not want to do this, just going to put this out there to see if you or others are interested. On our project, we use Require.js to manage our dependencies, and we were running into a race condition where the shimmed jQuery UI stuff was not attached to the object before angular got a hold of the jQuery object. As a result, `$.fn.sortable` wasn't available on the angular `element`, and we had a JS error. By using the global `$` object here, we ensure that everything is always good. This may or may not cause a performance hit, I imagine it's a minimal impact for this helpful return. Let me know what you think.
