### PR TITLE
Perf Improvement: don't digest after the $timeout.

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -75,7 +75,7 @@ angular.module('ui.sortable', [])
                 if (!!element.data('ui-sortable')) {
                   element.sortable('refresh');
                 }
-              });
+              }, 0, false);
             });
 
             callbacks.start = function(e, ui) {


### PR DESCRIPTION
As far as I can tell, the `$timeout` in the directive does not actually modify any code that would require a `$digest`, although `$timeout` automatically calls digest at the end of the function.

This causes unnecessary digests to happen too frequently on startup (when I have several `ui-sortable` directives), affecting my startup performance.

It seems to work to call `$timeout(callbac, 0, false)` which forgoes the `$digest` but everything still works.

I there any reason that this won't work in your `link` function?
