### PR TITLE
Support for enumerable structures other than Array

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -187,8 +187,9 @@ angular.module('ui.sortable', [])
               // moved here from another list
               if(ui.item.sortable.received && !ui.item.sortable.isCanceled()) {
                 scope.$apply(function () {
-                  ngModel.$modelValue.splice(ui.item.sortable.dropindex, 0,
-                                             ui.item.sortable.moved);
+                  Array.prototype.splice.call(ngModel.$modelValue,
+                                              ui.item.sortable.dropindex, 0,
+                                              ui.item.sortable.moved);
                 });
               }
             };
@@ -202,9 +203,10 @@ angular.module('ui.sortable', [])
                  !ui.item.sortable.isCanceled()) {
 
                 scope.$apply(function () {
-                  ngModel.$modelValue.splice(
-                    ui.item.sortable.dropindex, 0,
-                    ngModel.$modelValue.splice(ui.item.sortable.index, 1)[0]);
+                  Array.prototype.splice.call(ngModel.$modelValue,
+                      ui.item.sortable.dropindex, 0,
+                      Array.prototype.splice.call(ngModel.$modelValue,
+                        ui.item.sortable.index, 1)[0]);
                 });
               } else {
                 // if the item was not moved, then restore the elements
@@ -239,8 +241,8 @@ angular.module('ui.sortable', [])
               // so the next list can retrive it
               if (!ui.item.sortable.isCanceled()) {
                 scope.$apply(function () {
-                  ui.item.sortable.moved = ngModel.$modelValue.splice(
-                    ui.item.sortable.index, 1)[0];
+                  ui.item.sortable.moved = Array.prototype.splice.call(
+                    ngModel.$modelValue, ui.item.sortable.index, 1)[0];
                 });
               }
             };


### PR DESCRIPTION
By using the "call" version of Array.prototype.splice, using array-like
objects (objects with a length property) becomes possible.

When using ngRepeat with data from an AJAX-based backend it is possible
to delete two or more items in rapid succession and have to wait for an
AJAX web service to respond with a success or failure signal to
visually commit the deletion. In that situation, you may end up
cancelling one of the deletes and then the ngRepeat index does not
correspond with the backend structure, effectively removing the wrong
ngRepeat item because the index changed faster than the AJAX response
arrival. In such cases, using an array-like object works better.
