### PR TITLE
fix(sortable): fix 'data-ui-sortable' directive annotation error

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -76,7 +76,7 @@ angular.module('ui.sortable', [])
               $timeout(function() {
                 // ensure that the jquery-ui-sortable widget instance
                 // is still bound to the directive's element
-                if (!!element.data('ui-sortable')) {
+                if (!!element.sortable('instance')) {
                   element.sortable('refresh');
                 }
               }, 0, false);
@@ -87,7 +87,7 @@ angular.module('ui.sortable', [])
                 // since the drag has started, the element will be
                 // absolutely positioned, so we check its siblings
                 var siblings = ui.item.siblings();
-                angular.element(e.target).data('ui-sortable').floating = isFloating(siblings);
+                angular.element(e.target).sortable('instance').floating = isFloating(siblings);
               }
 
               // Save the starting position of dragged item
@@ -263,13 +263,13 @@ angular.module('ui.sortable', [])
             scope.$watch('uiSortable', function(newVal /*, oldVal*/) {
               // ensure that the jquery-ui-sortable widget instance
               // is still bound to the directive's element
-              if (!!element.data('ui-sortable')) {
+              if (!!element.sortable('instance')) {
                 angular.forEach(newVal, function(value, key) {
                   // if it's a custom option of the directive,
                   // handle it approprietly
                   if (key in directiveOpts) {
                     if (key === 'ui-floating' && (value === false || value === true)) {
-                      element.data('ui-sortable').floating = value;
+                      element.sortable('instance').floating = value;
                     }
 
                     opts[key] = value;

--- a/test/sortable.spec.js
+++ b/test/sortable.spec.js
@@ -77,6 +77,25 @@ describe('uiSortable', function() {
       });
     });
 
+    it('should refresh sortable properly after an apply [data-* anotation]', function() {
+      inject(function($compile, $rootScope, $timeout) {
+        var element;
+        var childScope = $rootScope.$new();
+        element = $compile('<ul data-ui-sortable="opts" data-ng-model="items"><li ng-repeat="item in items">{{ item }}</li></ul>')(childScope);
+        $rootScope.$apply(function() {
+          childScope.items = ['One', 'Two', 'Three'];
+          childScope.opts = {};
+        });
+
+        expect(function() {
+          $timeout.flush();
+        }).not.toThrow();
+
+        expect(childScope.items).toEqual(['One', 'Two', 'Three']);
+        expect(childScope.items).toEqual(listContent(element));
+      });
+    });
+
     it('should not refresh sortable if destroyed', function() {
       inject(function($compile, $rootScope, $timeout) {
         var element;
@@ -94,11 +113,50 @@ describe('uiSortable', function() {
       });
     });
 
+    it('should not refresh sortable if destroyed [data-* anotation]', function() {
+      inject(function($compile, $rootScope, $timeout) {
+        var element;
+        var childScope = $rootScope.$new();
+        element = $compile('<div><ul data-ui-sortable="opts" data-ng-model="items"><li ng-repeat="item in items">{{ item }}</li></ul></div>')(childScope);
+        $rootScope.$apply(function() {
+          childScope.items = ['One', 'Two', 'Three'];
+          childScope.opts = {};
+        });
+
+        element.remove(element.firstChild);
+        expect(function() {
+          $timeout.flush();
+        }).not.toThrow();
+
+      });
+    });
+
     it('should not try to apply options to a destroyed sortable', function() {
       inject(function($compile, $rootScope, $timeout) {
         var element;
         var childScope = $rootScope.$new();
         element = $compile('<div><ul ui-sortable="opts" ng-model="items"><li ng-repeat="item in items">{{ item }}</li></ul></div>')(childScope);
+        $rootScope.$apply(function() {
+          childScope.items = ['One', 'Two', 'Three'];
+          childScope.opts = {
+            update: function() {}
+          };
+
+          element.remove(element.firstChild);
+        });
+
+        expect(function() {
+          $timeout.flush();
+        }).not.toThrow();
+
+      });
+    });
+
+    it('should not try to apply options to a destroyed sortable [data-* anotation]', function() {
+      inject(function($compile, $rootScope, $timeout) {
+        var element;
+        var childScope = $rootScope.$new();
+        element = $compile('<div><ul data-ui-sortable="opts" data-ng-model="items"><li ng-repeat="item in items">{{ item }}</li></ul></div>')(childScope);
         $rootScope.$apply(function() {
           childScope.items = ['One', 'Two', 'Three'];
           childScope.opts = {


### PR DESCRIPTION
Resolves #313.

This way of retrieving the sortable widget instance is way less hacky.