### PR TITLE
Exposing license information according to bower format

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,6 @@
   "dependencies": {
     "angular": ">=1.2.x",
     "jquery-ui": ">=1.9"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Strange enough, licensing information is present on master, but all the releases (tags) lack it.