### PR TITLE
Only Start if not Disabled #2

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -448,7 +448,7 @@ angular.module('ui.sortable', [])
             $log.info('ui.sortable: ngModel not provided!', element);
           }
 
-          var listener = function() {};
+          var stopDisabledWatcher = angular.noop;
 
           var startIfEnabled = function()
           {
@@ -458,7 +458,7 @@ angular.module('ui.sortable', [])
               element.sortable(opts);
 
               // Stop Watcher
-              listener();
+              stopDisabledWatcher();
 
               return true;
             }
@@ -467,7 +467,7 @@ angular.module('ui.sortable', [])
 
           if(!startIfEnabled())
           {
-            listener = scope.$watch('uiSortable.disabled', startIfEnabled);
+            stopDisabledWatcher = scope.$watch('uiSortable.disabled', startIfEnabled);
           }
         }
       };

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -448,17 +448,27 @@ angular.module('ui.sortable', [])
             $log.info('ui.sortable: ngModel not provided!', element);
           }
 
-          var created = false;
-          scope.$watch('uiSortable.disabled', function()
-          {
-            if(!created && !scope.uiSortable.disabled)
-            {
-              created = true;
+          var listener = function() {};
 
+          var startIfEnabled = function()
+          {
+            if(!scope.uiSortable.disabled)
+            {
               // Create sortable
               element.sortable(opts);
+
+              // Stop Watcher
+              listener();
+
+              return true;
             }
-          });
+            return false;
+          };
+
+          if(!startIfEnabled())
+          {
+            listener = scope.$watch('uiSortable.disabled', startIfEnabled);
+          }
         }
       };
     }

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -448,8 +448,17 @@ angular.module('ui.sortable', [])
             $log.info('ui.sortable: ngModel not provided!', element);
           }
 
-          // Create sortable
-          element.sortable(opts);
+          var created = false;
+          scope.$watch('uiSortable.disabled', function()
+          {
+            if(!created && !scope.uiSortable.disabled)
+            {
+              created = true;
+
+              // Create sortable
+              element.sortable(opts);
+            }
+          });
         }
       };
     }


### PR DESCRIPTION
This is a follow up on this pull request: https://github.com/angular-ui/ui-sortable/pull/436
This new pull request is based on the 0.14 branch. Also, I made the changes in the code more obvious and you can see that I barely changed anything in the diff below.

Find the description of the original pull request below:

Unfortunately, jquery ui sortable is very slow sometimes, specially if there are hidden elements as described here: http://stackoverflow.com/questions/9440664/jquery-ui-sortable-drag-initiation-is-slow-when-container-has-hidden-items

This adds up to more than 150ms for me on every user action, which is absolutely inacceptable, because I only need to use ui-sortable in very few cases. I need to be able to disable it.

Right now, it is not possible to hold off on launching ui sortable, similar to the problem discussed here: #397
Unfortunately, disabling jquery ui sortable only prevents the dragging from working, without actually not running. It still does all the expensive calls to the refreshPositions function.

All I need is to hold off before the start if the disabled option is set. My change is only about 7 lines - I wrapped the executed code into a "main" function, and only call that function if disabled is not set. The diff below is misleading.

I really hope this, or a different solution, can make it into the main rep. Thanks!
