### PR TITLE
Fixed to work with deep descendants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# Notes for this for
-This fork modifies the sortable.js file at line 198, in order for the ui-sortable directive to work on other directives that have isolated scopes.  One example is the angular material tabs directive (https://material.angularjs.org/latest/demo/tabs).  To workaround the limitation of being unable to have two directives with isolated scopes on one element (not alowed by AngularJS), wrap the md-tabs element with an element containing the ui-sortable directive.  You must also set the sortable option, in the case of md-tabs, '"items": "md-tab-item"'.  I also noticed the example below didn't work until I added a "track by" on the ng-repeat.  
-
-See the live example on CodePen:
-http://codepen.io/yenoh2/pen/rWxxVJ
-
 # UI.Sortable directive
 [![npm](https://img.shields.io/npm/v/angular-ui-sortable.svg)](https://www.npmjs.com/package/angular-ui-sortable)
 [![npm](https://img.shields.io/npm/dm/angular-ui-sortable.svg)](https://www.npmjs.com/package/angular-ui-sortable)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Notes for this for
+This fork modifies the sortable.js file at line 198, in order for the ui-sortable directive to work on other directives that have isolated scopes.  One example is the angular material tabs directive (https://material.angularjs.org/latest/demo/tabs).  To workaround the limitation of being unable to have two directives with isolated scopes on one element (not alowed by AngularJS), wrap the md-tabs element with an element containing the ui-sortable directive.  You must also set the sortable option, in the case of md-tabs, '"items": "md-tab-item"'.  I also noticed the example below didn't work until I added a "track by" on the ng-repeat.  
+
+See the live example on CodePen:
+http://codepen.io/yenoh2/pen/rWxxVJ
+
 # UI.Sortable directive
 [![npm](https://img.shields.io/npm/v/angular-ui-sortable.svg)](https://www.npmjs.com/package/angular-ui-sortable)
 [![npm](https://img.shields.io/npm/dm/angular-ui-sortable.svg)](https://www.npmjs.com/package/angular-ui-sortable)

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -97,7 +97,7 @@ angular.module('ui.sortable', [])
                     }
                     return;
                   }
-                  
+
                   if (!defaultOptions) {
                     defaultOptions = angular.element.ui.sortable().options;
                   }
@@ -195,6 +195,11 @@ angular.module('ui.sortable', [])
                 break;
               }
             }
+            //If result is still null it means that the draggable (ng-repeat) item isn't a direct child of
+            //the element containing the ui.sortable directive.  This may be required when using the ui.sortable 
+            //directive with other directives that have isolated scopes.  This will compare x.element[0]
+            //with the closest ancestorof element[0] that has the ui-sortable attribute to get the applicable
+            //element scope.
             if (!result) {
               for (var i = 0; i < elementScopes.length; i++) {
                 var x = elementScopes[i];
@@ -381,7 +386,6 @@ angular.module('ui.sortable', [])
               if(!ui.item.sortable.received &&
                  ('dropindex' in ui.item.sortable) &&
                  !ui.item.sortable.isCanceled()) {
-
                 scope.$apply(function () {
                   ngModel.$modelValue.splice(
                     ui.item.sortable.dropindex, 0,
@@ -467,7 +471,7 @@ angular.module('ui.sortable', [])
               var sortableWidgetInstance = getSortableWidgetInstance(element);
               if (!!sortableWidgetInstance) {
                 var optsDiff = patchUISortableOptions(newVal, oldVal, sortableWidgetInstance);
-                
+
                 if (optsDiff) {
                   element.sortable('option', optsDiff);
                 }
@@ -483,7 +487,7 @@ angular.module('ui.sortable', [])
             } else {
               $log.info('ui.sortable: ngModel not provided!', element);
             }
-            
+
             // Create sortable
             element.sortable(opts);
           }

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -195,6 +195,15 @@ angular.module('ui.sortable', [])
                 break;
               }
             }
+            if (!result) {
+              for (var i = 0; i < elementScopes.length; i++) {
+                var x = elementScopes[i];
+                if (x.element[0] === element[0].closest("[ui-sortable]")) {
+                  result = x.scope;
+                  break;
+                }
+              }
+            }
             return result;
           }
 

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -196,14 +196,14 @@ angular.module('ui.sortable', [])
               }
             }
             //If result is still null it means that the draggable (ng-repeat) item isn't a direct child of
-            //the element containing the ui.sortable directive.  This may be required when using the ui.sortable 
+            //the element containing the ui.sortable directive.  This may be required when using the ui.sortable
             //directive with other directives that have isolated scopes.  This will compare x.element[0]
             //with the closest ancestorof element[0] that has the ui-sortable attribute to get the applicable
             //element scope.
             if (!result) {
-              for (var i = 0; i < elementScopes.length; i++) {
-                var x = elementScopes[i];
-                if (x.element[0] === element[0].closest("[ui-sortable]")) {
+              for (i = 0; i < elementScopes.length; i++) {
+                x = elementScopes[i];
+                if (x.element[0] === element[0].closest('[ui-sortable]')) {
                   result = x.scope;
                   break;
                 }


### PR DESCRIPTION
In trying to use ui-sortable with Angular Material tabs, I found that it didn't work for two reasons.  First you can't have two directives with an isolated scope on the same element.  Second, ui-sortable didn't support items that aren't a direct decendant.  I modified the "getElementScope" function to get the applicable scope for the draggable item, if the normal code results in null.  I also wrapped the md-tabs directive in a div containing the ui-sortable directive to circumvent the two directives with isolated scopes issues.  

As far as I can tell, this works.  Can you see any issues with my change?  

See the following example:
http://codepen.io/yenoh2/pen/rWxxVJ

This seems to be related to "Using ui.sortable with angular ui.bootstrap.tabs have a weird interaction #248"