### PR TITLE
Fixed to work with deep descendants

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -188,8 +188,10 @@ angular.module('ui.sortable', [])
 
           function getElementScope(elementScopes, element) {
             var result = null;
-            for (var i = 0; i < elementScopes.length; i++) {
-              var x = elementScopes[i];
+            var x = null;
+            var i = null;
+            for (i = 0; i < elementScopes.length; i++) {
+              x = elementScopes[i];
               if (x.element[0] === element[0]) {
                 result = x.scope;
                 break;

--- a/src/sortable.js
+++ b/src/sortable.js
@@ -97,7 +97,7 @@ angular.module('ui.sortable', [])
                     }
                     return;
                   }
-                  
+
                   if (!defaultOptions) {
                     defaultOptions = angular.element.ui.sortable().options;
                   }
@@ -193,6 +193,20 @@ angular.module('ui.sortable', [])
               if (x.element[0] === element[0]) {
                 result = x.scope;
                 break;
+              }
+            }
+            //If result is still null it means that the draggable (ng-repeat) item isn't a direct child of
+            //the element containing the ui.sortable directive.  This may be required when using the ui.sortable
+            //directive with other directives that have isolated scopes.  This will compare x.element[0]
+            //with the closest ancestorof element[0] that has the ui-sortable attribute to get the applicable
+            //element scope.
+            if (!result) {
+              for (i = 0; i < elementScopes.length; i++) {
+                x = elementScopes[i];
+                if (x.element[0] === element[0].closest('[ui-sortable]')) {
+                  result = x.scope;
+                  break;
+                }
               }
             }
             return result;
@@ -459,7 +473,7 @@ angular.module('ui.sortable', [])
               var sortableWidgetInstance = getSortableWidgetInstance(element);
               if (!!sortableWidgetInstance) {
                 var optsDiff = patchUISortableOptions(newVal, oldVal, sortableWidgetInstance);
-                
+
                 if (optsDiff) {
                   element.sortable('option', optsDiff);
                 }
@@ -475,7 +489,7 @@ angular.module('ui.sortable', [])
             } else {
               $log.info('ui.sortable: ngModel not provided!', element);
             }
-            
+
             // Create sortable
             element.sortable(opts);
           }


### PR DESCRIPTION
In trying to use ui-sortable with Angular Material tabs, I found that it didn't work for two reasons. First you can't have two directives with an isolated scope on the same element. Second, ui-sortable didn't support items that aren't a direct decendant. I modified the "getElementScope" function to get the applicable scope for the draggable item, if the normal code results in null. I also wrapped the md-tabs directive in a div containing the ui-sortable directive to circumvent the two directives with isolated scopes issues.

As far as I can tell, this works. Can you see any issues with my change?

See the following example:
http://codepen.io/yenoh2/pen/rWxxVJ

This seems to be related to "Using ui.sortable with angular ui.bootstrap.tabs have a weird interaction #248"