### PR TITLE
fix(sortable): fix incorrect helper returned from getSortingHelper(). (v0.14.x)

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -21,6 +21,7 @@ angular.module('ui.sortable', [])
         },
         link: function(scope, element, attrs, ngModel) {
           var savedNodes;
+          var helper;
 
           function combineCallbacks(first, second){
             var firstIsFunc = typeof first === 'function';
@@ -175,8 +176,7 @@ angular.module('ui.sortable', [])
             if (hasSortingHelper(element, ui) &&
                 element.sortable( 'option', 'appendTo' ) === 'parent') {
               // The .ui-sortable-helper element (that's the default class name)
-              // is placed last.
-              result = savedNodes.last();
+              result = helper;
             }
             return result;
           }
@@ -293,6 +293,7 @@ angular.module('ui.sortable', [])
               // This is inside activate (instead of start) in order to save
               // both lists when dragging between connected lists.
               savedNodes = element.contents();
+              helper = ui.helper;
 
               // If this list has a placeholder (the connected lists won't),
               // don't inlcude it in saved nodes.
@@ -394,9 +395,10 @@ angular.module('ui.sortable', [])
                 }
               }
 
-              // It's now safe to clear the savedNodes
+              // It's now safe to clear the savedNodes and helper
               // since stop is the last callback.
               savedNodes = null;
+              helper = null;
             };
 
             callbacks.receive = function(e, ui) {


### PR DESCRIPTION
The helper element is not always in the last position while created
from a function and append it to another DOM.

E.g. the following will mess up the DOM position after canceled update.

```
var sortableOption = {
  helper: function (evt, ui) {
    return ui.clone().appendTo('body');
  }
};
```