### PR TITLE
Allow ui-sortable to work on deep items

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -218,8 +218,10 @@ angular.module('ui.sortable', [])
           // we can't just do ui.item.index() because there it might have siblings
           // which are not items
           function getItemIndex(item) {
-            return item.parent()
-              .find(opts['ui-model-items'])
+            var par = item.parent();
+            while (!par.attr('ui-sortable')) par = par.parent();
+            return par
+              .find(opts['items'])
               .index(item);
           }
 


### PR DESCRIPTION
The sortable container might not be the item's direct parent; this
happens eg. in floating setups when the ng-repeated DOM node is a
directive that only includes the floating node as a child, so the
resulting tree with directives and CSS resolved looks like

    <div ng-model="items" ui-sortable="{items:'.tilefloater'}">
      <tile ng-repeat="i in items>
        <tile-implementation class="tilefloater" sytle="float:left" ... />
      </tile>
    </div>

I'm unsure on why the .find(opts['ui-model-items']) ->
.find(opts['items']) is necessary exactly (or why it doesn't say the
latter originally), but it is required in the same situation; were I to
(just on a guess) set {ui-model-items:'.tilefloater',
items:'.tilefloater'}, there'd be leftover placeholders, and without the
change, .find() doesn't catch the actually moved item.