### PR TITLE
Add run-time dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "license": "MIT",
   "homepage": "http://angular-ui.github.com",
   "main": "./src/sortable.js",
-  "dependencies": {},
+  "dependencies": {
+    "angular": ">=1.2.x",
+    "jquery": ">=3.1.x",
+    "jquery-ui": ">=1.12.x"
+  },
   "devDependencies": {
     "angular-ui-publisher": "1.2.x",
     "grunt": "~0.4.x",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "angular": ">=1.2.x",
     "jquery": ">=3.1.x",
-    "jquery-ui": ">=1.12.x"
+    "jquery-ui-dist": ">=1.12.x"
   },
   "devDependencies": {
     "angular-ui-publisher": "1.2.x",


### PR DESCRIPTION
The run-time dependencies when pulled in through NPM do not match the run-time dependencies listed in the Bower package. This means that when using NPM for dependency management the package's dependencies will not be pulled in. This update simply makes the dependencies in package.json match those of bower.json.